### PR TITLE
docs: add API reference and deployment guide

### DIFF
--- a/.github/changes/feature_docs-4644.md
+++ b/.github/changes/feature_docs-4644.md
@@ -1,0 +1,10 @@
+# docs: add API reference and deployment guide
+
+## Summary
+- Auto-generated API docs from docstrings
+- Deployment guide for AWS ECS
+- Architecture decision records
+
+## Review checklist
+- [x] All public APIs documented
+- [x] Examples compile and run


### PR DESCRIPTION
## Summary
- Auto-generated API docs from docstrings
- Deployment guide for AWS ECS
- Architecture decision records

## Review checklist
- [x] All public APIs documented
- [x] Examples compile and run
- [x] Links are valid